### PR TITLE
Abandon codecov.io and use romeovs/lcov-reporter-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
     - name: Create Comment if Pull Request
       uses: actions/github-script@v4
-      if: ${{ github.event_name === 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         script: |
           github.issues.createComment({
@@ -49,7 +49,7 @@ jobs:
           })
     - name: Create Commit Comment if Push
       uses: actions/github-script@v4
-      if: ${{ github.event_name === 'push' }}
+      if: ${{ github.event_name == 'push' }}
       with:
         script: |
           github.issues.createCommitComment({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,25 +36,30 @@ jobs:
         path: ./coverage/
     - run: ls -R
     - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
-    - name: Create Comment if Pull Request
-      uses: actions/github-script@v4
-      if: ${{ github.event_name == 'pull_request' }}
+    - run: cat ./coverage/body.html
+    - uses: actions/github-script@v4
       with:
         script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: ./coverage/body.html
-          })
-    - name: Create Commit Comment if Push
-      uses: actions/github-script@v4
-      if: ${{ github.event_name == 'push' }}
-      with:
-        script: |
-          github.issues.createCommitComment({
-            commit_sha: options.commit,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: ./coverage/body.html
-          })
+          const path = require('path')
+          const body = require(path.resolve('./coverage/body.html'))({context})
+          fs = require('fs');
+          fs.readFile('./coverage/body.html', 'utf8', function (error,data) {
+            if (error) {
+              core.debug(error)
+            }
+            if (context.eventName === "pull_request") {
+              github.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: data
+              })
+            } else if (context.eventName === "push") {
+              github.issues.createCommitComment({
+                commit_sha: options.commit,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: data
+              })
+            }
+          });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,24 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: romeovs/lcov-reporter-action@v0.2.16
+    - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
+    - uses: actions/github-script@v4
+      if: ${{ context.eventName === "pull_request" }}
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ./coverage/body.html
+            })
+    - uses: actions/github-script@v4
+      if: ${{ context.eventName === "push" }}
+        with:
+          script: |
+            github.issues.createCommitComment({
+              commit_sha: options.commit,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ./coverage/body.html
+            })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,26 +40,24 @@ jobs:
     - uses: actions/github-script@v4
       with:
         script: |
-          const path = require('path')
-          const body = require(path.resolve('./coverage/body.html'))({context})
           fs = require('fs');
           fs.readFile('./coverage/body.html', 'utf8', function (error,data) {
             if (error) {
-              core.debug(error)
+              console.log(error)
             }
             if (context.eventName === "pull_request") {
               github.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `${data}`
+                body: data
               })
             } else if (context.eventName === "push") {
               github.issues.createCommitComment({
                 commit_sha: options.commit,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: `${data}`
+                body: data
               })
             }
           });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: HackingGate/lcov-reporter-action@46cac5a3137acc58b8cb52704616f7edc1c82384
+    - uses: HackingGate/lcov-reporter-action@50d98a6e28f590b6e996f436bd726b93b7157a23
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: Test with Code Coverage
       run: swift test --enable-code-coverage --filter '^((?!ipv6).)*$'
-    - name: Generate Codecov Report
-      run: llvm-cov export -format="lcov" .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > SwiftPublicIPPackageTests.lcov
+    - name: Report Codecov
+      run: | 
+        llvm-cov report .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile=.build/debug/codecov/default.profdata -use-color
+    - name: Export Codecov
+      run: |
+        mkdir -p coverage
+        llvm-cov export -format="lcov" .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov
-        path: SwiftPublicIPPackageTests.lcov
+        path: ./coverage/lcov.info
   codecov:
     needs: test
     runs-on: ubuntu-latest
@@ -28,12 +33,6 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov
+        path: ./coverage/lcov.info
     - run: ls -R
-    - uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./SwiftPublicIPPackageTests.lcov
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
-        verbose: true
+    - uses: romeovs/lcov-reporter-action@v0.2.16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
+    - uses: HackingGate/lcov-reporter-action@14c98c8f711581c38179224281b18ba9f3c8d00e
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
     - name: Convert Absolute Path to Relative Path
       run: sed -i "s~${PWD}~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
+      if: ${{ github.event == 'pull_request' }}
+      with:
+        name: ${{ github.head_ref }}-codecov
+        path: ./coverage/lcov-base.info
+    - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/lcov.info
@@ -33,11 +38,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2
+      if: ${{ github.event == 'pull_request' }}
+      with:
+        name: ${{ github.base_ref }}-codecov
+        path: ./coverage/
+    - uses: actions/download-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
     - uses: HackingGate/lcov-reporter-action@7bf132b5f872f17fde607a37b7ca2308510abbb4
+      with:
+        lcov-base: ./coverage/lcov-base.info
+        lcov-file: ./coverage/lcov.info
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,7 @@ jobs:
       run: sed -i "s~${PWD}/~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{ github.head_ref }}-codecov
-        path: ./coverage/lcov-base.info
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.run_id }}-codecov
+        name: lcov.info
         path: ./coverage/lcov.info
         retention-days: 1
   codecov:
@@ -41,13 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2
-      if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: ${{ github.base_ref }}-codecov
-        path: ./coverage/
-    - uses: actions/download-artifact@v2
-      with:
-        name: ${{ github.run_id }}-codecov
+        name: lcov.info
         path: ./coverage/
     - run: ls -R
     - uses: HackingGate/lcov-reporter-action@7bf132b5f872f17fde607a37b7ca2308510abbb4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       uses: actions/github-script@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.issues.createComment({
             issue_number: context.issue.number,
@@ -52,7 +51,6 @@ jobs:
       uses: actions/github-script@v4
       if: ${{ github.event_name == 'push' }}
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.issues.createCommitComment({
             commit_sha: options.commit,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: HackingGate/lcov-reporter-action@50d98a6e28f590b6e996f436bd726b93b7157a23
+    - uses: HackingGate/lcov-reporter-action@abccf7fbb7f35f7956e4a5fb8c1f49c3ba172167
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: HackingGate/lcov-reporter-action@abccf7fbb7f35f7956e4a5fb8c1f49c3ba172167
+    - uses: HackingGate/lcov-reporter-action@7bf132b5f872f17fde607a37b7ca2308510abbb4
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       uses: actions/github-script@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.issues.createComment({
             issue_number: context.issue.number,
@@ -51,6 +52,7 @@ jobs:
       uses: actions/github-script@v4
       if: ${{ github.event_name == 'push' }}
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.issues.createCommitComment({
             commit_sha: options.commit,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,23 +36,25 @@ jobs:
         path: ./coverage/
     - run: ls -R
     - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
-    - uses: actions/github-script@v4
+    - name: Create Comment if Pull Request
+      uses: actions/github-script@v4
       if: ${{ context.eventName === "pull_request" }}
-        with:
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ./coverage/body.html
-            })
-    - uses: actions/github-script@v4
+      with:
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: ./coverage/body.html
+          })
+    - name: Create Commit Comment if Push
+      uses: actions/github-script@v4
       if: ${{ context.eventName === "push" }}
-        with:
-          script: |
-            github.issues.createCommitComment({
-              commit_sha: options.commit,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ./coverage/body.html
-            })
+      with:
+        script: |
+          github.issues.createCommitComment({
+            commit_sha: options.commit,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: ./coverage/body.html
+          })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
     - name: Create Comment if Pull Request
       uses: actions/github-script@v4
-      if: ${{ github.event_name === "pull_request" }}
+      if: ${{ github.event_name === 'pull_request' }}
       with:
         script: |
           github.issues.createComment({
@@ -49,7 +49,7 @@ jobs:
           })
     - name: Create Commit Comment if Push
       uses: actions/github-script@v4
-      if: ${{ github.event_name === "push" }}
+      if: ${{ github.event_name === 'push' }}
       with:
         script: |
           github.issues.createCommitComment({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         mkdir -p coverage
         llvm-cov export -format="lcov" .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > ./coverage/lcov.info
     - name: Convert Absolute Path to Relative Path
-      run: sed -i "s~${PWD}~~g" ./coverage/lcov.info
+      run: sed -i "s~${PWD}/~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.head_ref }}-codecov
@@ -32,7 +32,7 @@ jobs:
       with:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/lcov.info
-	retention-days: 1
+        retention-days: 1
   codecov:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: HackingGate/lcov-reporter-action@8e0e2f75214b17f82a09ba15ad79ab96b25c7cf4
     - name: Create Comment if Pull Request
       uses: actions/github-script@v4
-      if: ${{ context.eventName === "pull_request" }}
+      if: ${{ github.event_name === "pull_request" }}
       with:
         script: |
           github.issues.createComment({
@@ -49,7 +49,7 @@ jobs:
           })
     - name: Create Commit Comment if Push
       uses: actions/github-script@v4
-      if: ${{ context.eventName === "push" }}
+      if: ${{ github.event_name === "push" }}
       with:
         script: |
           github.issues.createCommitComment({

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,6 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov
-        path: ./coverage/lcov.info
+        path: ./coverage/
     - run: ls -R
     - uses: romeovs/lcov-reporter-action@v0.2.16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Convert Absolute Path to Relative Path
       run: sed -i "s~${PWD}~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
-      if: ${{ github.event == 'pull_request' }}
       with:
         name: ${{ github.head_ref }}-codecov
         path: ./coverage/lcov-base.info
@@ -33,12 +32,13 @@ jobs:
       with:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/lcov.info
+	retention-days: 1
   codecov:
     needs: test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v2
-      if: ${{ github.event == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         name: ${{ github.base_ref }}-codecov
         path: ./coverage/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         name: ${{ github.run_id }}-codecov
         path: ./coverage/
     - run: ls -R
-    - uses: HackingGate/lcov-reporter-action@14c98c8f711581c38179224281b18ba9f3c8d00e
+    - uses: HackingGate/lcov-reporter-action@46cac5a3137acc58b8cb52704616f7edc1c82384
     - run: cat ./coverage/body.html
     - uses: actions/github-script@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         mkdir -p coverage
         llvm-cov export -format="lcov" .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > ./coverage/lcov.info
+    - name: Convert Absolute Path to Relative Path
+      run: sed -i "s~/__w/Swift-Public-IP/Swift-Public-IP/~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    paths:
+      - '.github/workflows/test.yml'
+      - '**/*.swift'
+      - 'Tests/**'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,14 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: data
+                body: `${data}`
               })
             } else if (context.eventName === "push") {
               github.issues.createCommitComment({
                 commit_sha: options.commit,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: data
+                body: `${data}`
               })
             }
           });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         mkdir -p coverage
         llvm-cov export -format="lcov" .build/debug/SwiftPublicIPPackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > ./coverage/lcov.info
     - name: Convert Absolute Path to Relative Path
-      run: sed -i "s~/__w/Swift-Public-IP/Swift-Public-IP/~~g" ./coverage/lcov.info
+      run: sed -i "s~${PWD}~~g" ./coverage/lcov.info
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ github.run_id }}-codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Swift-Public-IP
 [![SwiftLint](https://github.com/HackingGate/Swift-Public-IP/actions/workflows/swiftlint.yml/badge.svg)](https://github.com/HackingGate/Swift-Public-IP/actions/workflows/swiftlint.yml)
 [![Test](https://github.com/HackingGate/Swift-Public-IP/actions/workflows/test.yml/badge.svg)](https://github.com/HackingGate/Swift-Public-IP/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/HackingGate/Swift-Public-IP/branch/master/graph/badge.svg?token=euyimOnZ1U)](https://codecov.io/gh/HackingGate/Swift-Public-IP)
 
 Swift library for checking your public IP address
 


### PR DESCRIPTION
### Reason to abandon codecov.io
I've already tried `json` and `lcov` formats. Bash uploader returns success but the web always shows:
"Coverage is either being processed, there has been no coverage report uploaded, or there was an error processing."
It's hard to debug because I don't know what exact the situation is.